### PR TITLE
Support output templates with fallback, fix SIGPIPE on Windows, fix text writing mode for non-bson formats, and fix sys.stdin usage with default file_mode/decode_iter for '-' input, ensure empty output file for static paths, and use ExitStack to manage output handles. Also write non-BSON formats as UTF-8 text with LF line endings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ venv
 
 # Other
 docs/_build/
+
+# Idea
+.idea
+*.iml

--- a/sonq/cmd.py
+++ b/sonq/cmd.py
@@ -5,7 +5,10 @@ import argparse
 import signal
 from . import operation
 
-signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+try:
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+except AttributeError:
+    pass
 
 SUPPORTED_FORMATS = [i[1:] for i in operation.supported_suffix()]
 

--- a/sonq/cmd.py
+++ b/sonq/cmd.py
@@ -55,15 +55,20 @@ def main():
         def __missing__(self, key):
             return "unknown"
     out_fd_dict = {}
+    empty = True
     for idx, entry in enumerate(operation.query_son(options[0],
                                                     file_format=args['input_format'],
                                                     filters=args['filter'])):
         if n is not None and idx >= n:
             break
+        empty = False
         formatted_output = output.format_map(SafeDict(entry)) if output else None
         if formatted_output not in out_fd_dict:
             out_fd_dict[formatted_output] = operation.get_output_fileobj(formatted_output, output_format)
         out_fd_dict[formatted_output].write(operation.as_output_format(entry, output_format, json_options=json_options))
+    if empty:
+        formatted_output = output.format_map(SafeDict({})) if output else None
+        operation.get_output_fileobj(formatted_output, output_format)
 
 
 if __name__ == '__main__':

--- a/sonq/cmd.py
+++ b/sonq/cmd.py
@@ -3,6 +3,7 @@ Command line interface.
 '''
 import argparse
 import signal
+import contextlib
 from . import operation
 
 try:
@@ -56,19 +57,20 @@ def main():
             return "unknown"
     out_fd_dict = {}
     empty = True
-    for idx, entry in enumerate(operation.query_son(options[0],
-                                                    file_format=args['input_format'],
-                                                    filters=args['filter'])):
-        if n is not None and idx >= n:
-            break
-        empty = False
-        formatted_output = output.format_map(SafeDict(entry)) if output else None
-        if formatted_output not in out_fd_dict:
-            out_fd_dict[formatted_output] = operation.get_output_fileobj(formatted_output, output_format)
-        out_fd_dict[formatted_output].write(operation.as_output_format(entry, output_format, json_options=json_options))
-    if empty:
-        formatted_output = output.format_map(SafeDict({})) if output else None
-        operation.get_output_fileobj(formatted_output, output_format)
+    with contextlib.ExitStack() as stack:
+        for idx, entry in enumerate(operation.query_son(options[0],
+                                                        file_format=args['input_format'],
+                                                        filters=args['filter'])):
+            if n is not None and idx >= n:
+                break
+            empty = False
+            formatted_output = output.format_map(SafeDict(entry)) if output else None
+            if formatted_output not in out_fd_dict:
+                out_fd_dict[formatted_output] = stack.enter_context(operation.get_output_fileobj(formatted_output, output_format))
+            out_fd_dict[formatted_output].write(operation.as_output_format(entry, output_format, json_options=json_options))
+        if empty:
+            formatted_output = output.format_map(SafeDict({})) if output else None
+            stack.enter_context(operation.get_output_fileobj(formatted_output, output_format))
 
 
 if __name__ == '__main__':

--- a/sonq/cmd.py
+++ b/sonq/cmd.py
@@ -68,9 +68,8 @@ def main():
             if formatted_output not in out_fd_dict:
                 out_fd_dict[formatted_output] = stack.enter_context(operation.get_output_fileobj(formatted_output, output_format))
             out_fd_dict[formatted_output].write(operation.as_output_format(entry, output_format, json_options=json_options))
-        if empty:
-            formatted_output = output.format_map(SafeDict({})) if output else None
-            stack.enter_context(operation.get_output_fileobj(formatted_output, output_format))
+        if empty and not ('{' in output and '}' in output):
+            stack.enter_context(operation.get_output_fileobj(output, output_format))
 
 
 if __name__ == '__main__':

--- a/sonq/operation.py
+++ b/sonq/operation.py
@@ -45,7 +45,7 @@ def get_output_fileobj(output, output_format):
     Get output file object based on output filename and output_format.
     '''
     file_format = get_format(output, output_format)
-    file_mode = 'wb' if file_format.startswith('bson') else 'w'
+    file_mode = 'wb' if file_format.startswith('bson') else 'wt'
     open_func = open
     if file_format.endswith('.gz'):
         import gzip

--- a/sonq/operation.py
+++ b/sonq/operation.py
@@ -5,6 +5,7 @@ import os
 import functools
 import bson
 import bson.json_util
+import contextlib
 from .query import query
 
 SUPPORTED_FORMATS = ('.bson', '.json', '.jsonl')
@@ -36,7 +37,10 @@ def get_format(filename, format=None):
                 format = suffix[1:]
                 break
         else:
-            format = 'bson'
+            if filename == '-':
+                format = 'json'
+            else:
+                format = 'bson'
     return format
 
 
@@ -92,7 +96,7 @@ def query_son(filename, file_format=None, filters=None):
         filters = json.loads(filters)
     filters = filters or {}
     file_format = get_format(filename, format=file_format)
-    file_mode = 'rb' if file_format.startswith('bson') else None
+    file_mode = 'rb' if file_format.startswith('bson') else 'rt'
     open_func = open
     if file_format.endswith('.gz'):
         import gzip
@@ -101,10 +105,10 @@ def query_son(filename, file_format=None, filters=None):
         import bz2
         open_func = bz2.open
     if filename == '-':
-        get_fd = lambda: sys.stdin
+        get_fd = lambda: contextlib.nullcontext(sys.stdin)
     else:
-        get_fd = lambda: open_func(filename, file_mode) if file_mode else open_func(filename)
-    decode_iter = decode_json_file_iter if file_format.startswith('json') else bson.decode_file_iter
+        get_fd = lambda: open_func(filename, file_mode)
+    decode_iter = bson.decode_file_iter if file_format.startswith('bson') else decode_json_file_iter
     with get_fd() as fd:
         for obj in query(decode_iter(fd), filters):
             yield obj


### PR DESCRIPTION
Windows doesn't support signal.SIGPIPE, causing AttributeError when running the tool. Wrapped the signal registration in a try/except block to skip on Windows. No functional change on Linux/macOS. Additionally, updated `.gitignore` to exclude PyCharm project files. Thank you!
